### PR TITLE
styled links inside alerts

### DIFF
--- a/src/components/alerts/InfoAlert.html
+++ b/src/components/alerts/InfoAlert.html
@@ -15,6 +15,8 @@
   <p>
     This is a demonstration of a information type alert message. This additional
     text is to demonstrate how it wraps over multiple-lines. Interactive
-    elements like <a href="#">hyperlinks</a> maintain consistent styling.
+    elements like
+    <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">hyperlinks</a>
+    maintain consistent styling.
   </p>
 </div>

--- a/standalone-components-css/src/components/alert.css
+++ b/standalone-components-css/src/components/alert.css
@@ -23,7 +23,7 @@
   }
 
   .alert a {
-    font-weight: 700;
+    font-weight: var(--font-weight-bold);
   }
   .alert a:hover {
     text-decoration: underline;


### PR DESCRIPTION
Alerts often display markup containing hyperlinks. This should be styled by default

before:

<img width="946" alt="image" src="https://github.com/user-attachments/assets/da9c6e9d-dc8b-42c1-9e60-47b650130463" />

after
<img width="912" alt="image" src="https://github.com/user-attachments/assets/d04c6f8d-5127-454e-940a-2bcbf473ba6a" />

See myprotein:

<img width="859" alt="image" src="https://github.com/user-attachments/assets/268fd03c-6bbf-405f-a3a4-4d3ff625943c" />
