### PR TITLE
Add rollup dependencies to CSS package for polyfill build

### DIFF
--- a/standalone-components-css/package.json
+++ b/standalone-components-css/package.json
@@ -22,5 +22,9 @@
     "dist/",
     "README.md"
   ],
-  "dependencies": {}
+  "dependencies": {},
+  "devDependencies": {
+    "rollup": "^4.28.0",
+    "@rollup/plugin-terser": "^0.4.4"
+  }
 }


### PR DESCRIPTION
Adds rollup and @rollup/plugin-terser as devDependencies to the CSS package to ensure the polyfill can be built during npm publish.

Fixes: "rollup: not found" error during GitHub Actions npm publish
