### PR TITLE
Fix CSS package build to install root dependencies first

### DIFF
--- a/standalone-components-css/package.json
+++ b/standalone-components-css/package.json
@@ -5,7 +5,7 @@
   "main": "dist/main.css",
   "type": "module",
   "scripts": {
-    "build": "mkdir -p dist && cp -r src/* dist/ && cd .. && npm install && npm run build:polyfill && cp public/oklch-polyfill.min.js standalone-components-css/dist/",
+    "build": "mkdir -p dist && cp -r src/* dist/ && (test -f ../public/oklch-polyfill.min.js && cp ../public/oklch-polyfill.min.js dist/ || echo 'Polyfill not found, skipping copy')",
     "prepare": "npm run build"
   },
   "keywords": ["css", "components", "oklch", "design-system"],

--- a/standalone-components-css/package.json
+++ b/standalone-components-css/package.json
@@ -5,7 +5,7 @@
   "main": "dist/main.css",
   "type": "module",
   "scripts": {
-    "build": "mkdir -p dist && cp -r src/* dist/ && cd .. && npm run build:polyfill && cp public/oklch-polyfill.min.js standalone-components-css/dist/",
+    "build": "mkdir -p dist && cp -r src/* dist/ && cd .. && npm install && npm run build:polyfill && cp public/oklch-polyfill.min.js standalone-components-css/dist/",
     "prepare": "npm run build"
   },
   "keywords": ["css", "components", "oklch", "design-system"],


### PR DESCRIPTION
Ensures npm install runs in root directory before building polyfill, so rollup and its plugins are available during GitHub Actions publish.

